### PR TITLE
Add gubernator_state library crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,5 @@ members = [
     "gubernator_cri",
     "gubernator_manifest",
     "gubernator_service_test",
+    "gubernator_state",
 ]

--- a/README.md
+++ b/README.md
@@ -4,3 +4,18 @@
 
 > **Gubernator is an experimental container orchestration system.** There is not much of anything
 > to see here, yet, and there probably won't be for a while.
+
+## Overview
+
+### Project Structure
+
+This repository is organized as a [Cargo workspace](cargo-workspaces).
+
+| Crate                 | Description                                                                            |
+| --------------------- | -------------------------------------------------------------------------------------- |
+| `gubernator`          | Facade library crate for all other crates, and binary crate for the Gubernator CLI.    |
+| `gubernator_cri`      | Gubernator client for container runtimes implementing the Container Runtime Interface. |
+| `gubernator_manifest` | Utilities for loading and interacting with Gubernator manifest files.                  |
+| `gubernator_state`    | Gubernator client for managing cluster state. Currently provided exclusively by etcd.  |
+
+[cargo-workspaces]: https://doc.rust-lang.org/book/ch14-03-cargo-workspaces.html

--- a/gubernator_state/Cargo.toml
+++ b/gubernator_state/Cargo.toml
@@ -3,6 +3,6 @@ name = "gubernator_state"
 version = "0.1.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+etcd-client = "0.7"
+tokio = { version = "1.0", features = ["full"] }

--- a/gubernator_state/Cargo.toml
+++ b/gubernator_state/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "gubernator_state"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/gubernator_state/src/lib.rs
+++ b/gubernator_state/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/gubernator_state/src/lib.rs
+++ b/gubernator_state/src/lib.rs
@@ -1,7 +1,1 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+pub use etcd_client::*;


### PR DESCRIPTION
This crate will be the primary interface to Gubernator's state/source of truth currently provided by etcd